### PR TITLE
Add bicep module for Virtual Machine Scale Set and use if from core.

### DIFF
--- a/deployments/modules/virtualMachineScaleSet.bicep
+++ b/deployments/modules/virtualMachineScaleSet.bicep
@@ -1,0 +1,103 @@
+param vmssName string = 'DevopsBuildAgentScaleSet'
+
+param vnetResourceGroupName string
+param subnetName string
+param vnetName string
+
+param location string = resourceGroup().location
+
+param adminUserName string
+param adminPassword string {
+  secure: true
+}
+
+var subscriptionId = subscription().subscriptionId
+
+resource virtualMachineScaleSet 'Microsoft.Compute/virtualMachineScaleSets@2020-06-01' = {
+  name: vmssName
+  location: location
+  sku: {
+    name: 'Standard_D2s_v3'
+    tier: 'Standard'
+    capacity: 0
+  }
+  properties: {
+    singlePlacementGroup: true
+    upgradePolicy: {
+      mode: 'Manual'
+    }
+    scaleInPolicy: {
+      rules: [
+        'Default'
+      ]
+    }
+    virtualMachineProfile: {
+      osProfile: {
+        computerNamePrefix: 'devopsbui'
+        adminUsername: adminUserName
+        adminPassword: adminPassword
+          linuxConfiguration: {
+          disablePasswordAuthentication: false
+          provisionVMAgent: true
+        }
+        secrets: []
+      }
+      storageProfile: {
+        osDisk: {
+          osType: 'Linux'
+          createOption: 'FromImage'
+          caching: 'ReadWrite'
+          managedDisk: {
+            storageAccountType: 'Premium_LRS'
+          }
+          diskSizeGB: 30
+        }
+        imageReference: {
+          publisher: 'Canonical'
+          offer: 'UbuntuServer'
+          sku: '18.04-LTS'
+          version: 'latest'
+        }
+      }
+      networkProfile: {
+        networkInterfaceConfigurations: [
+          {
+            name: 'contoso-hub-nic01'
+            properties: {
+              primary: true
+              enableAcceleratedNetworking: false
+              dnsSettings: {
+                dnsServers: []
+              }
+              enableIPForwarding: false
+              ipConfigurations: [
+                {
+                  name: 'contoso-hub-nic01-defaultIpConfiguration'
+                  properties: {
+                    primary: true
+                    subnet: {
+                      id: resourceId(subscriptionId, vnetResourceGroupName, 'Microsoft.Network/virtualNetworks/subnets', vnetName, subnetName)
+                    }
+                    privateIPAddressVersion: 'IPv4'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+      diagnosticsProfile: {
+        bootDiagnostics: {
+          enabled: true
+        }
+      }
+      extensionProfile: {
+        extensions: []
+      }
+      priority: 'Regular'
+    }
+    overprovision: false
+    doNotRunExtensionsOnOverprovisionedVMs: false
+    platformFaultDomainCount: 5
+  }
+}


### PR DESCRIPTION
Create a Virtual Machine Scale Set to be used for hosting Azure Devops build agent(s). The new VMSS resides in the hub vnet in its own new subnet with settings similar to that of the existing desktop subnet. I will update the documentation on a subsequent PR. Hoping to get these changes in before the impending forking of the repository...

